### PR TITLE
DAOS-11506 Added task to wait for daos port

### DIFF
--- a/roles/daos/tasks/storage.yml
+++ b/roles/daos/tasks/storage.yml
@@ -15,6 +15,17 @@
     state: started
   when: daos_role_server in daos_roles
 
+- name: Wait for daos port
+  ansible.builtin.wait_for:
+    port: "{{ daos_port | default('10001') }}"
+    state: started
+    delay: 5
+    sleep: 2
+    timeout: 300
+  become: false
+  changed_when: false
+  when: daos_role_server in daos_roles
+
 - name: Ensure that the daos_agent service is started
   ansible.builtin.service:
     name: daos_agent


### PR DESCRIPTION
Wait for daos port before attempting to restart agents or formatting storage.

Signed-off-by: Mark Olson <115657904+mark-olson@users.noreply.github.com>